### PR TITLE
Animation Keys

### DIFF
--- a/lib/data/keys.dart
+++ b/lib/data/keys.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class Keys {
+  static const aboutMenuButton = Key("about_menu_button");
+  static const experienceMenuButton = Key("experience_menu_button");
+  static const projectsMenuButton = Key("projects_menu_button");
+  static const contactMenuButton = Key("contact_menu_button");
+  static const resumeMenuButton = Key("resume_menu_button");
+
+  static const greeting = Key("greeting");
+  static const nameTitle = Key("name_title");
+  static const introText = Key("intro_text");
+  static const backgroundPicture = Key("background_picture");
+
+  static const aboutSection = Key("about_section");
+  static const aboutMe = Key("about_me");
+  static const myPicture = Key("my_picture");
+
+  static const projectsSection = Key("projects_section");
+  static const projectsButton = Key("projects_button");
+
+  static const workSection = Key("work_section");
+  static const kcfTechnologies = Key("kcf_technologies");
+  static const volvo = Key("volvo");
+  static const mule = Key("mule");
+
+  static const footerText = Key("footer_text");
+  static const footerContact = Key("footer_contact");
+  static const socialMedia = Key("social_media");
+  static const copyright = Key("copyright");
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -18,7 +18,7 @@ class Home extends StatelessWidget {
   static final List<GlobalKey> dataKeys =
       List.generate(4, (index) => GlobalKey());
 
-  const Home({Key? key}) : super(key: key);
+  const Home({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,5 +1,6 @@
 import 'package:auto_animated/auto_animated.dart';
 import 'package:flutter/material.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/data/url.dart';
 import 'package:personal_website/sections/about/about.dart';
@@ -63,7 +64,7 @@ class Home extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.end,
           children: <Widget>[
             SlideAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.aboutMenuButton,
               slideDown: true,
               child: MenuButtton(
                 dataKey: dataKeys[0],
@@ -73,7 +74,7 @@ class Home extends StatelessWidget {
             ),
             const SizedBox(width: 8.0),
             SlideAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.experienceMenuButton,
               slideDown: true,
               delay: const Duration(milliseconds: 50),
               child: MenuButtton(
@@ -84,7 +85,7 @@ class Home extends StatelessWidget {
             ),
             const SizedBox(width: 8.0),
             SlideAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.projectsMenuButton,
               slideDown: true,
               delay: const Duration(milliseconds: 100),
               child: MenuButtton(
@@ -95,7 +96,7 @@ class Home extends StatelessWidget {
             ),
             const SizedBox(width: 8.0),
             SlideAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.contactMenuButton,
               slideDown: true,
               delay: const Duration(milliseconds: 150),
               child: MenuButtton(
@@ -106,7 +107,7 @@ class Home extends StatelessWidget {
             ),
             const SizedBox(width: 12.0),
             SlideAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.resumeMenuButton,
               slideDown: true,
               delay: const Duration(milliseconds: 200),
               child: OutlinedButton(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ void main() {
 }
 
 class PersonalWebsite extends StatelessWidget {
-  const PersonalWebsite({Key? key}) : super(key: key);
+  const PersonalWebsite({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/about/about.dart
+++ b/lib/sections/about/about.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/sections/about/about_me.dart';
 import 'package:personal_website/sections/about/my_picture.dart';
 import 'package:personal_website/widgets/fade_animation.dart';
@@ -22,18 +23,18 @@ class About extends StatelessWidget {
                       ? 80.0
                       : 0.0),
               if (ResponsiveWidget.isAtLeastLargeScreen(context))
-                FadeAnimation(
-                  animationKey: UniqueKey(),
-                  delay: const Duration(milliseconds: 1000),
-                  child: const MyPicture(),
+                const FadeAnimation(
+                  animationKey: Keys.myPicture,
+                  delay: Duration(milliseconds: 1000),
+                  child: MyPicture(),
                 ),
             ],
           ),
           if (!ResponsiveWidget.isAtLeastLargeScreen(context))
-            FadeAnimation(
-              animationKey: UniqueKey(),
-              delay: const Duration(milliseconds: 1000),
-              child: const MyPicture(),
+            const FadeAnimation(
+              animationKey: Keys.myPicture,
+              delay: Duration(milliseconds: 1000),
+              child: MyPicture(),
             ),
         ],
       ),

--- a/lib/sections/about/about.dart
+++ b/lib/sections/about/about.dart
@@ -6,7 +6,7 @@ import 'package:personal_website/widgets/fade_animation.dart';
 import 'package:personal_website/widgets/responsive_widget.dart';
 
 class About extends StatelessWidget {
-  const About({Key? key}) : super(key: key);
+  const About({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/about/about_me.dart
+++ b/lib/sections/about/about_me.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/data/url.dart';
 import 'package:personal_website/utils/theme.dart';
@@ -26,16 +27,16 @@ class _AboutMeState extends State<AboutMe> {
     return Flexible(
       child: Column(
         children: <Widget>[
-          SlideAnimation(
-            animationKey: UniqueKey(),
-            delay: const Duration(milliseconds: 50),
-            child: const SectionTitle(
+          const SlideAnimation(
+            animationKey: Keys.aboutSection,
+            delay: Duration(milliseconds: 50),
+            child: SectionTitle(
               number: SectionTitleData.sectionNumber1,
               title: SectionTitleData.section1Title,
             ),
           ),
           FadeAnimation(
-            animationKey: UniqueKey(),
+            animationKey: Keys.aboutMe,
             delay: const Duration(milliseconds: 150),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/sections/about/about_me.dart
+++ b/lib/sections/about/about_me.dart
@@ -13,7 +13,7 @@ import 'package:personal_website/widgets/slide_animation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class AboutMe extends StatefulWidget {
-  const AboutMe({Key? key}) : super(key: key);
+  const AboutMe({super.key});
 
   @override
   State<AboutMe> createState() => _AboutMeState();

--- a/lib/sections/about/my_picture.dart
+++ b/lib/sections/about/my_picture.dart
@@ -3,7 +3,7 @@ import 'package:personal_website/utils/theme.dart';
 import 'package:personal_website/widgets/responsive_widget.dart';
 
 class MyPicture extends StatefulWidget {
-  const MyPicture({Key? key}) : super(key: key);
+  const MyPicture({super.key});
 
   @override
   State<MyPicture> createState() => _MyPictureState();

--- a/lib/sections/footer/footer.dart
+++ b/lib/sections/footer/footer.dart
@@ -13,7 +13,7 @@ import 'package:personal_website/widgets/slide_animation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Footer extends StatefulWidget {
-  const Footer({Key? key}) : super(key: key);
+  const Footer({super.key});
 
   @override
   State<Footer> createState() => _FooterState();

--- a/lib/sections/footer/footer.dart
+++ b/lib/sections/footer/footer.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/data/url.dart';
 import 'package:personal_website/utils/theme.dart';
@@ -31,25 +32,25 @@ class _FooterState extends State<Footer> {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.footerText,
                   delay: const Duration(milliseconds: 50),
                   child: _footerText(context),
                 ),
                 const SizedBox(height: 32.0),
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.footerContact,
                   delay: const Duration(milliseconds: 150),
                   child: _contact(),
                 ),
                 const SizedBox(height: 40.0),
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.socialMedia,
                   delay: const Duration(milliseconds: 250),
                   child: _socialMedia(context),
                 ),
                 const SizedBox(height: 40.0),
                 FadeAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.copyright,
                   delay: const Duration(milliseconds: 350),
                   child: _copyright(),
                 ),

--- a/lib/sections/intro/intro.dart
+++ b/lib/sections/intro/intro.dart
@@ -11,7 +11,7 @@ import 'package:personal_website/widgets/slide_animation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Intro extends StatelessWidget {
-  const Intro({Key? key}) : super(key: key);
+  const Intro({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/intro/intro.dart
+++ b/lib/sections/intro/intro.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/data/url.dart';
 import 'package:personal_website/utils/theme.dart';
@@ -25,7 +26,7 @@ class Intro extends StatelessWidget {
         children: <Widget>[
           if (ResponsiveWidget.isAtLeastLargeScreen(context))
             FadeAnimation(
-              animationKey: UniqueKey(),
+              animationKey: Keys.backgroundPicture,
               delay: const Duration(milliseconds: 750),
               child: Image.asset(
                 'assets/intro_background.png',
@@ -40,20 +41,20 @@ class Intro extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.greeting,
                   delay: const Duration(milliseconds: 750),
                   child: _greeting(),
                 ),
                 const SizedBox(height: 25.0),
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.nameTitle,
                   delay: const Duration(milliseconds: 850),
                   child: _nameAndTitle(context),
                 ),
                 SizedBox(
                     height: ResponsiveWidget.isSmallScreen(context) ? 16 : 0),
                 SlideAnimation(
-                  animationKey: UniqueKey(),
+                  animationKey: Keys.introText,
                   delay: const Duration(milliseconds: 900),
                   child: _about(),
                 ),

--- a/lib/sections/projects/projects.dart
+++ b/lib/sections/projects/projects.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:auto_animated/auto_animated.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/utils/theme.dart';
 import 'package:personal_website/widgets/fade_animation.dart';
@@ -49,10 +50,10 @@ class _ProjectsState extends State<Projects> {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          SlideAnimation(
-            animationKey: UniqueKey(),
-            delay: const Duration(milliseconds: 50),
-            child: const SectionTitle(
+          const SlideAnimation(
+            animationKey: Keys.projectsSection,
+            delay: Duration(milliseconds: 50),
+            child: SectionTitle(
               number: SectionTitleData.sectionNumber3,
               title: SectionTitleData.section3Title,
             ),
@@ -100,7 +101,7 @@ class _ProjectsState extends State<Projects> {
             padding: const EdgeInsets.symmetric(vertical: 48.0),
             child: Center(
               child: FadeAnimation(
-                animationKey: UniqueKey(),
+                animationKey: Keys.projectsButton,
                 delay: const Duration(milliseconds: 50),
                 child: OutlinedButton(
                   style: ButtonStyles.primary,

--- a/lib/sections/projects/projects.dart
+++ b/lib/sections/projects/projects.dart
@@ -13,7 +13,7 @@ import 'package:personal_website/widgets/section_title.dart';
 import 'package:personal_website/widgets/slide_animation.dart';
 
 class Projects extends StatefulWidget {
-  const Projects({Key? key}) : super(key: key);
+  const Projects({super.key});
 
   @override
   State<Projects> createState() => _ProjectsState();

--- a/lib/sections/work/kcf_technologies.dart
+++ b/lib/sections/work/kcf_technologies.dart
@@ -14,10 +14,10 @@ class KcfTechnologies extends StatelessWidget {
   final AutoSizeGroup titleGroup;
 
   const KcfTechnologies({
-    Key? key,
+    super.key,
     required this.pointGroup,
     required this.titleGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/work/mule.dart
+++ b/lib/sections/work/mule.dart
@@ -14,10 +14,10 @@ class Mule extends StatelessWidget {
   final AutoSizeGroup titleGroup;
 
   const Mule({
-    Key? key,
+    super.key,
     required this.pointGroup,
     required this.titleGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/work/volvo.dart
+++ b/lib/sections/work/volvo.dart
@@ -14,10 +14,10 @@ class Volvo extends StatelessWidget {
   final AutoSizeGroup titleGroup;
 
   const Volvo({
-    Key? key,
+    super.key,
     required this.pointGroup,
     required this.titleGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/sections/work/work.dart
+++ b/lib/sections/work/work.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:personal_website/data/keys.dart';
 import 'package:personal_website/data/text.dart';
 import 'package:personal_website/sections/work/kcf_technologies.dart';
 import 'package:personal_website/sections/work/mule.dart';
@@ -27,29 +28,29 @@ class Work extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          SlideAnimation(
-            animationKey: UniqueKey(),
-            delay: const Duration(milliseconds: 50),
-            child: const SectionTitle(
+          const SlideAnimation(
+            animationKey: Keys.workSection,
+            delay: Duration(milliseconds: 50),
+            child: SectionTitle(
               number: SectionTitleData.sectionNumber2,
               title: SectionTitleData.section2Title,
             ),
           ),
           FadeAnimation(
-            animationKey: UniqueKey(),
+            animationKey: Keys.kcfTechnologies,
             delay: const Duration(milliseconds: 100),
             child:
                 KcfTechnologies(pointGroup: pointGroup, titleGroup: titleGroup),
           ),
           const SizedBox(height: 32.0),
           FadeAnimation(
-            animationKey: UniqueKey(),
+            animationKey: Keys.volvo,
             delay: const Duration(milliseconds: 100),
             child: Volvo(pointGroup: pointGroup, titleGroup: titleGroup),
           ),
           const SizedBox(height: 32.0),
           FadeAnimation(
-            animationKey: UniqueKey(),
+            animationKey: Keys.mule,
             delay: const Duration(milliseconds: 100),
             child: Mule(pointGroup: pointGroup, titleGroup: titleGroup),
           ),

--- a/lib/sections/work/work.dart
+++ b/lib/sections/work/work.dart
@@ -11,7 +11,7 @@ import 'package:personal_website/widgets/section_title.dart';
 import 'package:personal_website/widgets/slide_animation.dart';
 
 class Work extends StatelessWidget {
-  const Work({Key? key}) : super(key: key);
+  const Work({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/bullet.dart
+++ b/lib/widgets/bullet.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:personal_website/widgets/triangular_bullet.dart';
 
 class Bullet extends StatelessWidget {
-  const Bullet({Key? key}) : super(key: key);
+  const Bullet({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/clickable_icon.dart
+++ b/lib/widgets/clickable_icon.dart
@@ -8,13 +8,12 @@ class ClickableIcon extends StatefulWidget {
   final double iconSize;
   final Color iconColor;
   final String url;
-  const ClickableIcon({
-    super.key,
-    required this.icon,
-    required this.iconSize,
-    required this.url,
-    this.iconColor = AppColors.lightGrey1
-  });
+  const ClickableIcon(
+      {super.key,
+      required this.icon,
+      required this.iconSize,
+      required this.url,
+      this.iconColor = AppColors.lightGrey1});
 
   @override
   State<ClickableIcon> createState() => _ClickableIconState();

--- a/lib/widgets/clickable_icon.dart
+++ b/lib/widgets/clickable_icon.dart
@@ -8,13 +8,13 @@ class ClickableIcon extends StatefulWidget {
   final double iconSize;
   final Color iconColor;
   final String url;
-  const ClickableIcon(
-      {Key? key,
-      required this.icon,
-      required this.iconSize,
-      required this.url,
-      this.iconColor = AppColors.lightGrey1})
-      : super(key: key);
+  const ClickableIcon({
+    super.key,
+    required this.icon,
+    required this.iconSize,
+    required this.url,
+    this.iconColor = AppColors.lightGrey1
+  });
 
   @override
   State<ClickableIcon> createState() => _ClickableIconState();

--- a/lib/widgets/date_range.dart
+++ b/lib/widgets/date_range.dart
@@ -7,10 +7,10 @@ class DateRange extends StatelessWidget {
   final String end;
 
   const DateRange({
-    Key? key,
+    super.key,
     required this.start,
     required this.end,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/fade_animation.dart
+++ b/lib/widgets/fade_animation.dart
@@ -8,12 +8,12 @@ class FadeAnimation extends StatelessWidget {
   final Widget child;
 
   const FadeAnimation({
-    Key? key,
+    super.key,
     required this.animationKey,
     required this.child,
     this.delay = const Duration(milliseconds: 0),
     this.duration = const Duration(milliseconds: 500),
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/fade_animation.dart
+++ b/lib/widgets/fade_animation.dart
@@ -2,7 +2,7 @@ import 'package:auto_animated/auto_animated.dart';
 import 'package:flutter/material.dart';
 
 class FadeAnimation extends StatelessWidget {
-  final UniqueKey animationKey;
+  final Key animationKey;
   final Duration duration;
   final Duration delay;
   final Widget child;

--- a/lib/widgets/menu_button.dart
+++ b/lib/widgets/menu_button.dart
@@ -7,11 +7,11 @@ class MenuButtton extends StatelessWidget {
   final GlobalKey<State<StatefulWidget>> dataKey;
 
   const MenuButtton({
-    Key? key,
+    super.key,
     required this.dataKey,
     required this.buttonNumber,
     required this.buttonTitle,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/project.dart
+++ b/lib/widgets/project.dart
@@ -12,12 +12,12 @@ class Project extends StatefulWidget {
   final List tags;
 
   const Project({
-    Key? key,
+    super.key,
     required this.title,
     required this.description,
     required this.url,
     required this.tags,
-  }) : super(key: key);
+  });
 
   @override
   State<Project> createState() => _ProjectState();

--- a/lib/widgets/recent_tech.dart
+++ b/lib/widgets/recent_tech.dart
@@ -8,9 +8,9 @@ import 'package:personal_website/widgets/responsive_widget.dart';
 class RecentTech extends StatelessWidget {
   final String title;
   const RecentTech({
-    Key? key,
+    super.key,
     required this.title,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/responsive_widget.dart
+++ b/lib/widgets/responsive_widget.dart
@@ -6,11 +6,11 @@ class ResponsiveWidget extends StatelessWidget {
   final Widget? smallScreen;
 
   const ResponsiveWidget({
-    Key? key,
+    super.key,
     required this.largeScreen,
     this.mediumScreen,
     this.smallScreen,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/section_title.dart
+++ b/lib/widgets/section_title.dart
@@ -8,10 +8,10 @@ class SectionTitle extends StatelessWidget {
   final String title;
 
   const SectionTitle({
-    Key? key,
+    super.key,
     required this.number,
     required this.title,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/slide_animation.dart
+++ b/lib/widgets/slide_animation.dart
@@ -2,7 +2,7 @@ import 'package:auto_animated/auto_animated.dart';
 import 'package:flutter/material.dart';
 
 class SlideAnimation extends StatelessWidget {
-  final UniqueKey animationKey;
+  final Key animationKey;
   final bool slideDown;
   final Duration duration;
   final Duration delay;

--- a/lib/widgets/slide_animation.dart
+++ b/lib/widgets/slide_animation.dart
@@ -9,13 +9,13 @@ class SlideAnimation extends StatelessWidget {
   final Widget child;
 
   const SlideAnimation({
-    Key? key,
+    super.key,
     required this.animationKey,
     required this.child,
     this.slideDown = false,
     this.delay = const Duration(milliseconds: 0),
     this.duration = const Duration(milliseconds: 300),
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/work_point.dart
+++ b/lib/widgets/work_point.dart
@@ -4,9 +4,9 @@ import 'package:personal_website/widgets/bullet.dart';
 class WorkPoint extends StatelessWidget {
   final Widget data;
   const WorkPoint({
-    Key? key,
+    super.key,
     required this.data,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/work_title.dart
+++ b/lib/widgets/work_title.dart
@@ -11,12 +11,12 @@ class WorkTitle extends StatelessWidget {
   final AutoSizeGroup group;
 
   const WorkTitle({
-    Key? key,
+    super.key,
     required this.title,
     required this.company,
     required this.url,
     required this.group,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -106,7 +106,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -121,6 +121,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -134,7 +141,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -153,7 +160,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -188,14 +195,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   url_launcher:
     dependency: "direct main"
     description:
@@ -258,7 +258,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   visibility_detector:
     dependency: transitive
     description:
@@ -267,5 +267,5 @@ packages:
     source: hosted
     version: "0.2.2"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #19 

The problem was not so much replaying the animation as rebuilding the element tree. We were passing unique keys to the SlideAnimation widget and we initialized them inside the build method build()->_appBar()

Every time setState is called or like in our case, exiting the site area, Flutter sees new keys every time and considers that these are new elements - redrawing them and playing the animation first once (not re-animating)